### PR TITLE
feat: :sparkles: add function to show APN DNS settings

### DIFF
--- a/zte.js
+++ b/zte.js
@@ -1941,6 +1941,10 @@ function inject_html()
 
             <div class="spacing_links"></div>
 
+            Config: <a onclick="config_SHOW_APN_DNS()">APN DNS</a>
+            
+            <div class="spacing_links"></div>
+
             <a onclick="reboot()">Reboot Router</a>
             <br>
             
@@ -1951,6 +1955,21 @@ function inject_html()
 
     <div class="spacing"></div>
     `)
+}
+
+function set_config(key, value){
+    if (typeof require.s.contexts._.defined["config/config"][key] === "undefined") {
+        console.log("Config key not found, setting it anyway: " + key);
+    } else {
+        console.log("Previous config value: " + require.s.contexts._.defined["config/config"][key]);
+    }
+    console.log("Setting config: " + key + " to " + value);
+    require.s.contexts._.defined["config/config"][key] = value;
+}
+
+function config_SHOW_APN_DNS(){
+    const value = prompt("Show APN DNS settings? (true/false)", "true");
+    set_config("SHOW_APN_DNS", value === "true");
 }
 
 prepare_1_timer_id = window.setInterval(prepare_1, 250);


### PR DESCRIPTION
Code only tested on MC888A.

- added utility function `set_config` to manipulate the config module
- added button and function to specific set the SHOW_APN_DNS config option

(I saw this pull request https://github.com/tpoechtrager/ZTE-Web-Script/pull/2 which shows the APN_DNS, which only shows it but not saves it for me but I leave it as it is. Because it may work for others)

![image](https://github.com/user-attachments/assets/9c132a28-5724-451e-99f8-1f1d89e1ed17)

![image](https://github.com/user-attachments/assets/34550b05-f367-4fb1-9539-e682dd23ad5c)
