### PR TITLE
fix pci parcing and add two more IP to be matched

### DIFF
--- a/greasemonkey/ZTE-Web-Script.user.js
+++ b/greasemonkey/ZTE-Web-Script.user.js
@@ -5,9 +5,13 @@
 // @match        https://192.168.0.1/*
 // @match        https://192.168.1.1/*
 // @match        https://192.168.2.1/*
+// @match        https://192.168.254.1/*
+// @match        https://192.168.5.1/*
 // @match        http://192.168.0.1/*
 // @match        http://192.168.1.1/*
 // @match        http://192.168.2.1/*
+// @match        http://192.168.254.1/*
+// @match        http://192.168.5.1/*
 // @require      https://code.jquery.com/jquery-3.7.1.min.js
 // @grant        GM_xmlhttpRequest
 // ==/UserScript==
@@ -53,7 +57,7 @@
         }
     }
 
-    loadScript("https://cdn.jsdelivr.net/gh/tpoechtrager/ZTE-Web-Script/legacy/zte-script-legacy.js", function() {
+    loadScript("https://cdn.jsdelivr.net/gh/bmihovski/ZTE-Web-Script/legacy/zte-script-legacy.js", function() {
         console.log("ZTE-Web-Script loaded and executed.");
     }, function() {
         alert("Failed to load the ZTE-Web-Script");

--- a/greasemonkey/ZTE-Web-Script.user.js
+++ b/greasemonkey/ZTE-Web-Script.user.js
@@ -57,7 +57,7 @@
         }
     }
 
-    loadScript("https://cdn.jsdelivr.net/gh/bmihovski/ZTE-Web-Script/legacy/zte-script-legacy.js", function() {
+    loadScript("https://cdn.jsdelivr.net/gh/tpoechtrager/ZTE-Web-Script/legacy/zte-script-legacy.js", function() {
         console.log("ZTE-Web-Script loaded and executed.");
     }, function() {
         alert("Failed to load the ZTE-Web-Script");

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -842,7 +842,7 @@ function get_status()
                         {
                             var cell = ngbr_cells[i];
                             var [earfcn, pci, rsrq, rsrp, rssi] = cell.split(",");
-                            html += "<tr><td>"+ pci + ":</td><td>EARFCN: " + earfcn + " </td>;<td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB</td>;</td><td>RSSI: " + rssi + " dBm</td></tr>";
+                            html += "<tr><td>"+ pci + ":" + earfcn + " </td>;<td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB&nbsp;</td><td>RSSI: " + rssi + " dBm</td></tr>";
                         }
                         html += "</table>";
                     }

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -714,6 +714,8 @@ function get_status()
                 if (!isNaN(decimalValue)) {
                     $("#cell_id").text(decimalValue);
                     $("#cell").show();
+                    // Also update the global variable to decimal
+                    window.cell_id = decimalValue.toString();
                 } else {
                     console.error("Invalid hex value:", cell_id);
                     $("#cell").hide();

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -838,11 +838,17 @@ function get_status()
                     if (ngbr_cells.length > 0)
                     {
                         var html = "<table class='ngbr_cell_table'>";
-                        for (var i = 0; i < ngbr_cells.length; i++)
-                        {
+                        for (var i = 0; i < ngbr_cells.length; i++) {
                             var cell = ngbr_cells[i];
-                            var [earfcn, pci, rsrq, rsrp, rssi] = cell.split(",");
-                            html += "<tr><td>"+ pci + ":" + earfcn + " </td><td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB&nbsp;</td><td>RSSI: " + rssi + " dBm</td></tr>";
+                            if (!cell) continue; // Skip empty entries
+                        
+                            var parts = cell.split(",").map(part => part.trim());
+                            if (parts.length === 5) {
+                                var [earfcn, pci, rsrq, rsrp, rssi] = parts;
+                                html += `<tr><td>${pci}:${earfcn}</td><td>RSRP: ${rsrp} dBm&nbsp;</td><td>RSRQ: ${rsrq} dB&nbsp;</td><td>RSSI: ${rssi} dBm</td></tr>`;
+                            } else {
+                                console.error("Invalid cell data format:", cell);
+                            }
                         }
                         html += "</table>";
                     }

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -713,9 +713,9 @@ function get_status()
                 // Only show if conversion is valid
                 if (!isNaN(decimalValue)) {
                     $("#cell").show();
-                    $("#cell_id_decimal").text(decimalValue);
-                    // Also create a global variable in decimal
-                    window.cell_id_decimal = decimalValue.toString();
+                    $("#cell_id").text(decimalValue);
+                    // Also update the global variable to be in decimal
+                    window.cell_id = decimalValue.toString();
                 } else {
                     console.error("Invalid hex value:", cell_id);
                     $("#cell").hide();
@@ -1892,7 +1892,7 @@ function inject_html()
                     </tr>
                     <tr id="cell">
                         <td>CELL:</td>
-                        <td><span id="cell_id_decimal"></span></td>
+                        <td><span id="cell_id"></span></td>
                     </tr>
                     <tr id="5g_cell">
                         <td>5G CELL:</td>

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -842,7 +842,7 @@ function get_status()
                         {
                             var cell = ngbr_cells[i];
                             var [earfcn, pci, rsrq, rsrp, rssi] = cell.split(",");
-                            html += "<tr><td>"+ pci + ":" + earfcn + " </td>;<td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB&nbsp;</td><td>RSSI: " + rssi + " dBm</td></tr>";
+                            html += "<tr><td>"+ pci + ":" + earfcn + " </td><td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB&nbsp;</td><td>RSSI: " + rssi + " dBm</td></tr>";
                         }
                         html += "</table>";
                     }

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -493,7 +493,7 @@ function parse_lte_cell_info()
             continue;
 
         lte_cells.push(new LteCaCellInfo(
-            parseInt(scell_info[1], 16), // PCI
+            scell_info[1], // PCI
             "B" + scell_info[3], // Band
             scell_info[4], // Earfcn
             scell_info[5].replace(".0", ""), // Bandwidth

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -713,8 +713,7 @@ function get_status()
                 // Only show if conversion is valid
                 if (!isNaN(decimalValue)) {
                     $("#cell").show();
-                    // Also create a global variable in decimal
-                    window.cell_id_decimal = decimalValue.toString();
+                    $("#cell_id_decimal").text(decimalValue);
                 } else {
                     console.error("Invalid hex value:", cell_id);
                     $("#cell").hide();

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -841,8 +841,9 @@ function get_status()
                         for (var i = 0; i < ngbr_cells.length; i++)
                         {
                             var cell = ngbr_cells[i];
-                            var [freq, pci, rsrq, rsrp, rssi] = cell.split(",");
-                            html += "<tr><td>"+ pci + ":</td><td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB</td></tr>";
+                            var [freq, pci, rsrq, rsrp, rssi, snr] = cell.split(",");
+                            html += "<tr><td>"+ pci + ":</td><td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB</td>;</td><td>RSSI: " + rssi + " dBm</td>;</td><td>SINR: " + snr + " dB</td></tr>";
+                            html += "<tr><td>" + cell.split(",") + "</td></tr>";
                         }
                         html += "</table>";
                     }

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -841,9 +841,8 @@ function get_status()
                         for (var i = 0; i < ngbr_cells.length; i++)
                         {
                             var cell = ngbr_cells[i];
-                            var [freq, pci, rsrq, rsrp, rssi, snr] = cell.split(",");
-                            html += "<tr><td>"+ pci + ":</td><td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB</td>;</td><td>RSSI: " + rssi + " dBm</td>;</td><td>SINR: " + snr + " dB</td></tr>";
-                            html += "<tr><td>" + cell.split(",") + "</td></tr>";
+                            var [earfcn, pci, rsrq, rsrp, rssi] = cell.split(",");
+                            html += "<tr><td>"+ pci + ":</td><td>EARFCN: " + earfcn + " </td>;<td>RSRP: " + rsrp + " dBm&nbsp;</td><td>RSRQ: " + rsrq + " dB</td>;</td><td>RSSI: " + rssi + " dBm</td></tr>";
                         }
                         html += "</table>";
                     }

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -708,8 +708,21 @@ function get_status()
             if (network_provider_fullname != "") $("#provider").show();
             else $("#provider").hide();
 
-            if (cell_id) $("#cell").show();
-            else $("#cell").hide();
+            if (cell_id) {
+                const decimalValue = parseInt(cell_id, 16);
+                // Only show if conversion is valid
+                if (!isNaN(decimalValue)) {
+                    $("#cell_id").text(decimalValue);
+                    $("#cell").show();
+                } else {
+                    console.error("Invalid hex value:", cell_id);
+                    $("#cell").hide();
+                }
+            } else {
+                $("#cell").hide();
+            }
+
+
 
             if (is_5g && nr5g_cell_id) $("#5g_cell").show();
             else $("#5g_cell").hide();

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -714,6 +714,8 @@ function get_status()
                 if (!isNaN(decimalValue)) {
                     $("#cell").show();
                     $("#cell_id_decimal").text(decimalValue);
+                    // Also create a global variable in decimal
+                    window.cell_id_decimal = decimalValue.toString();
                 } else {
                     console.error("Invalid hex value:", cell_id);
                     $("#cell").hide();

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -725,7 +725,6 @@ function get_status()
             }
 
 
-
             if (is_5g && nr5g_cell_id) $("#5g_cell").show();
             else $("#5g_cell").hide();
 

--- a/legacy/zte-script-legacy.js
+++ b/legacy/zte-script-legacy.js
@@ -712,10 +712,9 @@ function get_status()
                 const decimalValue = parseInt(cell_id, 16);
                 // Only show if conversion is valid
                 if (!isNaN(decimalValue)) {
-                    $("#cell_id").text(decimalValue);
                     $("#cell").show();
-                    // Also update the global variable to decimal
-                    window.cell_id = decimalValue.toString();
+                    // Also create a global variable in decimal
+                    window.cell_id_decimal = decimalValue.toString();
                 } else {
                     console.error("Invalid hex value:", cell_id);
                     $("#cell").hide();
@@ -1892,7 +1891,7 @@ function inject_html()
                     </tr>
                     <tr id="cell">
                         <td>CELL:</td>
-                        <td><span id="cell_id"></span></td>
+                        <td><span id="cell_id_decimal"></span></td>
                     </tr>
                     <tr id="5g_cell">
                         <td>5G CELL:</td>


### PR DESCRIPTION
This pull request updates the ZTE web script and its legacy version to fix a data handling issue when CA PCI values. The most important changes include expanding the script's supported IP address ranges and modifying how LTE cell PCI values are parsed.

**Compatibility improvements:**

* [`greasemonkey/ZTE-Web-Script.user.js`](diffhunk://#diff-3d37dd725c592472c3b954f334e3a8fb5772cd0231a7c1b73035018449d01b9eR8-R14): Added new IP address patterns (`192.168.254.1` and `192.168.5.1`) to the `@match` list, allowing the script to run on more router models and configurations.

**LTE cell info parsing:**

* [`legacy/zte-script-legacy.js`](diffhunk://#diff-de2eba0d6db5a907698380ba99a4ed43e424cfe6d288dfde227120cee9caaa6bL496-R496): Updated the `parse_lte_cell_info()` function to use the raw PCI value from `scell_info[1]` instead of parsing it as a hexadecimal integer twice (bugfix).